### PR TITLE
feat(create_estimate): accept per-sub-service calculationComponents

### DIFF
--- a/index.js
+++ b/index.js
@@ -1019,7 +1019,10 @@ Each service needs: serviceCode, region, serviceName. monthlyCost is auto-calcul
 Optionally provide calculationComponents (key-value pairs from get_service_schema) for the estimate to render detailed configs when opened.
 Use the 'value' field (not the 'label') from option objects returned by get_service_schema.
 For frequency/fileSize fields, provide { value: number, unit: "unitString" }.
-Optionally provide a 'group' name for each service to organize them into groups.`,
+Optionally provide a 'group' name for each service to organize them into groups.
+For services that use sub-services (e.g. VPC's NAT gateway + VPN, S3's storage + data transfer), provide
+'subServices' as an array of { serviceCode, calculationComponents } — each entry overrides the schema
+defaults for that sub-service only. Sub-service codes are listed on get_service_schema for the parent.`,
   {
     name: z.string().describe("Estimate name"),
     services: z
@@ -1036,6 +1039,15 @@ Optionally provide a 'group' name for each service to organize them into groups.
           calculationComponents: z.record(z.any()).optional().describe("Key-value input params from get_service_schema"),
           templateId: z.string().optional().describe("Template ID for the service (auto-detected if not provided). Controls which configuration form is shown when editing."),
           group: z.string().optional().describe("Group name to organize this service under"),
+          subServices: z
+            .array(
+              z.object({
+                serviceCode: z.string().describe("Sub-service code (e.g. 'networkAddressTranslationNatGatewayVpc'). Discoverable via get_service_schema on the parent."),
+                calculationComponents: z.record(z.any()).describe("calculationComponents for the sub-service. Merged over schema defaults; same field-key conventions as the parent."),
+              })
+            )
+            .optional()
+            .describe("Per-sub-service calculationComponents for parents that use sub-services (VPC, S3, ELB, DynamoDB). Match by serviceCode; any sub-services not listed keep their schema defaults."),
         })
       )
       .describe("Array of services to include"),
@@ -1088,15 +1100,21 @@ Optionally provide a 'group' name for each service to organize them into groups.
           } catch { /* use empty inputs */ }
         }
 
-        // If service has subServices in its definition, build them properly
+        // If service has subServices in its definition, build them properly.
+        // User-provided overrides (svc.subServices) are merged over schema defaults,
+        // matched by serviceCode.
         if (def.subServices?.length) {
           subServices = [];
+          const subOverrides = Object.fromEntries(
+            (svc.subServices || []).map((s) => [s.serviceCode, s.calculationComponents || {}])
+          );
           for (const sub of def.subServices) {
+            const userCC = subOverrides[sub.serviceCode] || {};
             try {
               const subDef = await fetchJSON(API.serviceDef(sub.serviceCode));
               const subTemplateId = subDef.templates?.[0]?.id || null;
               const subInputs = extractInputs(subDef);
-              const subCC = buildCalcComponents(subInputs);
+              const subCC = buildCalcComponents(subInputs, userCC);
               subServices.push({
                 serviceCode: sub.serviceCode,
                 region: svc.region,
@@ -1107,13 +1125,19 @@ Optionally provide a 'group' name for each service to organize them into groups.
                 serviceCost: { monthly: 0, upfront: 0 },
               });
             } catch {
+              // Fetch failed — still honour user overrides if provided, normalising
+              // bare values to { value: ... } so they round-trip through saveAs.
+              const fallbackCC = {};
+              for (const [k, v] of Object.entries(userCC)) {
+                fallbackCC[k] = typeof v === "object" && v !== null && "value" in v ? v : { value: v };
+              }
               subServices.push({
                 serviceCode: sub.serviceCode,
                 region: svc.region,
                 estimateFor: sub.serviceCode,
                 version: "0.0.1",
                 description: null,
-                calculationComponents: {},
+                calculationComponents: fallbackCC,
                 serviceCost: { monthly: 0, upfront: 0 },
               });
             }

--- a/index.test.js
+++ b/index.test.js
@@ -942,3 +942,62 @@ describe("calculateServiceCostFromDefinition", () => {
     assert.deepEqual(result.calculationComponents, { qty: { value: 2 } });
   });
 });
+
+// buildCalcComponents is the merge engine that the new `subServices` override
+// path feeds into — verify it treats per-sub-service user overrides the same
+// way it treats parent-level overrides: defaults in, user values on top.
+describe("buildCalcComponents (sub-service override semantics)", () => {
+  const inputs = [
+    { id: "numberOfGateways", default: "1", type: "numericInput" },
+    { id: "regionalNatGatewayCount", default: "5", type: "numericInput" },
+    { id: "regionalNatGatewayAzCount", default: "3", type: "numericInput" },
+    {
+      id: "dataProcessedPerNATGateway",
+      default: "100",
+      type: "fileSize",
+      defaultUnit: "gb|month",
+    },
+  ];
+
+  it("returns schema defaults when user provides no overrides", () => {
+    const cc = buildCalcComponents(inputs, {});
+    assert.deepEqual(cc.numberOfGateways, { value: "1" });
+    assert.deepEqual(cc.regionalNatGatewayCount, { value: "5" });
+    assert.deepEqual(cc.regionalNatGatewayAzCount, { value: "3" });
+  });
+
+  it("overlays user values over defaults (partial override)", () => {
+    // Typical NAT-trim use case: keep numberOfGateways=1 but zero the regional fanout.
+    const cc = buildCalcComponents(inputs, {
+      regionalNatGatewayCount: "1",
+      regionalNatGatewayAzCount: "0",
+    });
+    assert.deepEqual(cc.numberOfGateways, { value: "1" });      // default preserved
+    assert.deepEqual(cc.regionalNatGatewayCount, { value: "1" });  // overridden
+    assert.deepEqual(cc.regionalNatGatewayAzCount, { value: "0" }); // overridden
+  });
+
+  it("preserves {value, unit} envelope for fileSize-shaped user inputs", () => {
+    const cc = buildCalcComponents(inputs, {
+      dataProcessedPerNATGateway: { value: "10", unit: "gb|month" },
+    });
+    assert.deepEqual(cc.dataProcessedPerNATGateway, { value: "10", unit: "gb|month" });
+  });
+});
+
+// The override lookup is: `Object.fromEntries(userOverrides.map(s => [s.serviceCode, s.calculationComponents]))`.
+// That's a shape assertion — verify it behaves as the subService loop expects.
+describe("subService override lookup", () => {
+  it("builds a code->components map and preserves empty objects", () => {
+    const userSubs = [
+      { serviceCode: "networkAddressTranslationNatGatewayVpc", calculationComponents: { numberOfGateways: "1" } },
+      { serviceCode: "vpnConnectionVpc", calculationComponents: {} },
+    ];
+    const map = Object.fromEntries(
+      userSubs.map((s) => [s.serviceCode, s.calculationComponents || {}])
+    );
+    assert.deepEqual(map.networkAddressTranslationNatGatewayVpc, { numberOfGateways: "1" });
+    assert.deepEqual(map.vpnConnectionVpc, {});
+    assert.equal(map.somethingElse, undefined);
+  });
+});


### PR DESCRIPTION
## Summary

Extends `create_estimate` with an optional per-service `subServices` field so callers can override `calculationComponents` on individual sub-services (the sub-entries that parents like VPC, S3, ELB, and DynamoDB decompose into).

Before this PR, sub-services were always populated from schema defaults — there was no way to pass user input through. The practical consequence hits hardest on VPC: the NAT gateway sub-service defaults `regionalNatGatewayCount` and `regionalNatGatewayAzCount` to non-zero values (5 and 3 at the time of writing), which silently adds hundreds of dollars of regional-NAT cost per VPC in every estimate.

## Usage

```js
{
  serviceCode: "amazonVirtualPrivateCloud",
  serviceName: "Amazon VPC",
  region: "eu-west-2",
  subServices: [
    {
      serviceCode: "networkAddressTranslationNatGatewayVpc",
      calculationComponents: {
        numberOfGateways: "1",
        regionalNatGatewayCount: "1",
        regionalNatGatewayAzCount: "1",
        regionalNatGatewayDataProcessed: { value: "0", unit: "gb|month" }
      }
    }
  ]
}
```

Any sub-service not listed in `subServices` keeps its schema defaults. Backwards compatible — services without the new field behave exactly as before.

## How

- Zod schema extended with `subServices: [{ serviceCode, calculationComponents }]?` on each service entry.
- In the sub-service population loop, user overrides are looked up by `serviceCode` and passed as the `userInputs` argument to `buildCalcComponents`, which already knows how to merge defaults with user values.
- The fallback branch (when fetching the sub-service definition fails) still honours user overrides, normalising bare scalar values to `{ value: ... }` so they round-trip through `saveAs` cleanly.
- Tool description updated to document the option and the main use case.

## Tests

4 new unit tests (60 passing total, up from 56):

```
buildCalcComponents (sub-service override semantics)
  ✓ returns schema defaults when user provides no overrides
  ✓ overlays user values over defaults (partial override)
  ✓ preserves {value, unit} envelope for fileSize-shaped user inputs
subService override lookup
  ✓ builds a code->components map and preserves empty objects
```

## End-to-end verification

A VPC payload with overridden NAT sub-service calcComponents was POSTed to `saveAs`, loaded back, and opened in the calculator.aws UI — the override values are preserved exactly and the UI's generated `configSummary` reflects the trimmed NAT configuration (one basic gateway, one regional NAT in one AZ, zero GB processed).

## Relation to other PRs

Independent of #6 (nested group hierarchies) — they touch different parts of `create_estimate` (payload tree vs sub-service components). Both can land in any order; trivial merge conflict on the zod schema field list if both are merged.