### PR TITLE
fix: refresh_estimate on mac

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -6,8 +6,8 @@ const NAV_TIMEOUT_MS = 45000;
 const BROWSER_TIMEOUT_MS = 90000; // Kill browser after 90s max
 let browserLock = null; // Simple mutex — one browser at a time
 
-function findChrome() {
-  try { return require('puppeteer').executablePath(); } catch {}
+async function findChrome() {
+  try { return await require('puppeteer').executablePath(); } catch {}
   const paths = process.platform === 'win32'
     ? ['C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe', 'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe']
     : ['/usr/bin/google-chrome', '/usr/bin/chromium', '/usr/bin/chromium-browser', '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'];
@@ -22,7 +22,7 @@ async function refreshEstimate(estimateUrl) {
   let resolve;
   browserLock = new Promise(r => { resolve = r; });
 
-  const executablePath = findChrome();
+  const executablePath = await findChrome();
   const browser = await puppeteer.launch({ executablePath, headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'] });
 
   // Hard timeout: kill browser if it hangs

--- a/package.json
+++ b/package.json
@@ -63,5 +63,8 @@
   },
   "optionalDependencies": {
     "puppeteer": "^25.0.0"
+  },
+  "devDependencies": {
+    "puppeteer": "^25.0.4"
   }
 }

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -1,0 +1,63 @@
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+
+describe('findChrome', () => {
+  const browserJsPath = require.resolve('../lib/browser.js');
+  const puppeteerPath = require.resolve('puppeteer');
+  let origPuppeteer;
+
+  beforeEach(() => {
+    origPuppeteer = require.cache[puppeteerPath];
+    delete require.cache[browserJsPath];
+  });
+
+  afterEach(() => {
+    if (origPuppeteer) require.cache[puppeteerPath] = origPuppeteer;
+    else delete require.cache[puppeteerPath];
+    delete require.cache[browserJsPath];
+  });
+
+  function mockPuppeteer(executablePath) {
+    require.cache[puppeteerPath] = {
+      id: puppeteerPath, filename: puppeteerPath, loaded: true,
+      exports: { executablePath },
+    };
+  }
+
+  it('is an async function', () => {
+    const { findChrome } = require('../lib/browser.js');
+    assert.strictEqual(findChrome.constructor.name, 'AsyncFunction');
+  });
+
+  it('resolves path when executablePath() returns a Promise (Puppeteer v21+)', async () => {
+    const FAKE = '/tmp/fake-chrome-async';
+    mockPuppeteer(() => Promise.resolve(FAKE));
+    const { findChrome } = require('../lib/browser.js');
+    const result = await findChrome();
+    assert.strictEqual(result, FAKE);
+    assert.notStrictEqual(result, '[object Promise]', 'must await the Promise, not coerce it to a string');
+  });
+
+  it('resolves path when executablePath() returns a string (Puppeteer v20 and below)', async () => {
+    const FAKE = '/tmp/fake-chrome-sync';
+    mockPuppeteer(() => FAKE);
+    const { findChrome } = require('../lib/browser.js');
+    const result = await findChrome();
+    assert.strictEqual(result, FAKE);
+  });
+
+  it('falls through to OS paths when puppeteer throws', async () => {
+    // Simulate puppeteer unavailable (MODULE_NOT_FOUND) or executablePath failing
+    mockPuppeteer(() => { throw new Error('Cannot find module puppeteer'); });
+    const { findChrome } = require('../lib/browser.js');
+    try {
+      const result = await findChrome();
+      assert.strictEqual(typeof result, 'string');
+      assert.notStrictEqual(result, '[object Promise]');
+    } catch (e) {
+      // Acceptable: no Chrome installed on this machine
+      assert.ok(e instanceof Error);
+      assert.ok(e.message.toLowerCase().includes('chrome') || e.message.toLowerCase().includes('chromium'));
+    }
+  });
+});


### PR DESCRIPTION
Fixes #8.

findChrome() called executablePath() synchronously but it returns a Promise in newer Puppeteer. This passes the promise as the Chrome path and breaks refresh_estimate on macOS.

**Changes:**
- findChrome() is now async
- executablePath() is awaited
- Added puppeteer as a devDependency for testing
- Added test/browser.test.js covering async/sync executablePath() behavior and the fallthrough case